### PR TITLE
Address TODOs generated by rails-template

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,5 +9,4 @@
 ROLLBAR_ACCESS_TOKEN=ROLLBAR_ACCESS_TOKEN
 ROLLBAR_ENV=development
 
-# TODO: Replace `rails-template` with the name of the app.
-DATABASE_URL=postgres://postgres@localhost:5432/rails-template-development
+DATABASE_URL=postgres://postgres@localhost:5432/roda-development

--- a/.env.test
+++ b/.env.test
@@ -5,5 +5,4 @@
 #
 # Reference: https://github.com/bkeepers/dotenv#what-other-env-files-can-i-use
 
-# TODO: Replace `rails-template` with the name of the app.
-DATABASE_URL=postgres://test@localhost:5432/rails-template-test
+DATABASE_URL=postgres://test@localhost:5432/roda-test

--- a/README.md
+++ b/README.md
@@ -1,28 +1,43 @@
-# Using this template
+# Report Overseas Development Assistance (RODA)
 
-Search for `TODO` across the project to customise the template to a project
-
-TODO: Remove this section from the README once complete
-
----
-
-# Rails Template
-
-TODO: replace README header with project name
-
-TODO: Add a summary of who the application is for and what it will do.
+This service enables the Department for Business, Energy and Industrial Strategy (BEIS) and their delivery partners to collect and report information on the spending of Overseas Development Assistance (ODA).
 
 ## Getting started
 
 1. copy `/.env.example` into `/.env.development.local`.
 
   Our intention is that the example should include enough to get the application started quickly. If this is not the case, please ask another developer for a copy of their `/.env.development.local` file.
+1. set up the local database
 
-TODO: Add getting started steps
+  ```bash
+  bundle exec rake db:setup
+  ```
+1. start the server
+
+  ```bash
+  bundle exec rails server
+  ```
 
 ## Running the tests
 
-TODO: Add testing instructions
+To run all the tests, and linters we use `rake`:
+
+```
+bundle exec rake
+```
+
+Under the hood this is using RSpec so normal commands can be used:
+
+```
+bundle exec rspec spec
+```
+
+### Initial set up
+
+```
+createuser --super test
+RAILS_ENV=test rake db:setup
+```
 
 ## Architecture decision records
 


### PR DESCRIPTION
## Changes in this PR

- address all but 1 TODO generated by the rails-template we have used to generate this repository
- the remaining one must remain until we have live environments to point to
- use the name `roda` as it is shorter and therefore more manageable than the full name