### PR TITLE
Deploy to staging (and production) with containers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,10 +25,15 @@ jobs:
     - RAILS_ENV=test
     script: bundle exec rake
 deploy:
-  provider: heroku
-  api_key:
-    secure: JwMXOsBBJl72mQ/o9YY/NEPF+WiRSN3hfZ7OT7MUAJSZuLxp5NLWdz4zVdrwUs8f2kfa6a1RpsWkl9CeY/eMB+8H7pIMBGivadfc9dA9TGQmhf1VdyOC6K79erHcc28CEHiO3DUIQVlzhSzpjNDEI/exlOVFt6wodcLBBLAtemlwiLHz5EKeUpMVuUX/wMHy5DDV+wYimbfA88R+nzwXHk6gXmeVM43BY3EDeIucItLf+ZONWuJxny72wd1bT4yoxqFy5ABNXK1YFzaT40wgWyR+OhdSYjXt/2h3dddhQ0/G5zAhAs+kLq74t9cTu2KVB/XMncDzKdlHr/0bmYPMqXxfhqbuzM8svMipLyuBej/NrK3ehUtfEiBsEMjzGfUmm3xZUx8QOAWpViwPl2Nl47DecAHjKTgqbqzjGy3HpwSNGR8wr3Vkz+U+iVaIcN6Az3HEnoBE7GugUPNRdnqPgefXuz6fTFpTGVKQiM8I0nkrG4K1+Csq0ZYunuaM69wMQE4gTnZUgWFLjtCEUnH7OlRPOi5dtdBtFBPPpEVHRhP9ZS/o3mAHHIi+mK9w+UCc8Yaoz5SS1q5c+m7D94Q3L9a6eVmSn92idg0V9E3og7RkObEdYg5hMcciz8gGIk6ONDweUEzGzhSDIXWiDg8BxUHaRwnphy29dI/Lfiluj5w=
-  on:
-    branch: develop
-  app: beis-roda-staging
-
+  - provider: heroku
+    api_key:
+      secure: JwMXOsBBJl72mQ/o9YY/NEPF+WiRSN3hfZ7OT7MUAJSZuLxp5NLWdz4zVdrwUs8f2kfa6a1RpsWkl9CeY/eMB+8H7pIMBGivadfc9dA9TGQmhf1VdyOC6K79erHcc28CEHiO3DUIQVlzhSzpjNDEI/exlOVFt6wodcLBBLAtemlwiLHz5EKeUpMVuUX/wMHy5DDV+wYimbfA88R+nzwXHk6gXmeVM43BY3EDeIucItLf+ZONWuJxny72wd1bT4yoxqFy5ABNXK1YFzaT40wgWyR+OhdSYjXt/2h3dddhQ0/G5zAhAs+kLq74t9cTu2KVB/XMncDzKdlHr/0bmYPMqXxfhqbuzM8svMipLyuBej/NrK3ehUtfEiBsEMjzGfUmm3xZUx8QOAWpViwPl2Nl47DecAHjKTgqbqzjGy3HpwSNGR8wr3Vkz+U+iVaIcN6Az3HEnoBE7GugUPNRdnqPgefXuz6fTFpTGVKQiM8I0nkrG4K1+Csq0ZYunuaM69wMQE4gTnZUgWFLjtCEUnH7OlRPOi5dtdBtFBPPpEVHRhP9ZS/o3mAHHIi+mK9w+UCc8Yaoz5SS1q5c+m7D94Q3L9a6eVmSn92idg0V9E3og7RkObEdYg5hMcciz8gGIk6ONDweUEzGzhSDIXWiDg8BxUHaRwnphy29dI/Lfiluj5w=
+    on:
+      branch: develop
+    app: beis-roda-staging
+  - provider: heroku
+    api_key:
+      secure: JwMXOsBBJl72mQ/o9YY/NEPF+WiRSN3hfZ7OT7MUAJSZuLxp5NLWdz4zVdrwUs8f2kfa6a1RpsWkl9CeY/eMB+8H7pIMBGivadfc9dA9TGQmhf1VdyOC6K79erHcc28CEHiO3DUIQVlzhSzpjNDEI/exlOVFt6wodcLBBLAtemlwiLHz5EKeUpMVuUX/wMHy5DDV+wYimbfA88R+nzwXHk6gXmeVM43BY3EDeIucItLf+ZONWuJxny72wd1bT4yoxqFy5ABNXK1YFzaT40wgWyR+OhdSYjXt/2h3dddhQ0/G5zAhAs+kLq74t9cTu2KVB/XMncDzKdlHr/0bmYPMqXxfhqbuzM8svMipLyuBej/NrK3ehUtfEiBsEMjzGfUmm3xZUx8QOAWpViwPl2Nl47DecAHjKTgqbqzjGy3HpwSNGR8wr3Vkz+U+iVaIcN6Az3HEnoBE7GugUPNRdnqPgefXuz6fTFpTGVKQiM8I0nkrG4K1+Csq0ZYunuaM69wMQE4gTnZUgWFLjtCEUnH7OlRPOi5dtdBtFBPPpEVHRhP9ZS/o3mAHHIi+mK9w+UCc8Yaoz5SS1q5c+m7D94Q3L9a6eVmSn92idg0V9E3og7RkObEdYg5hMcciz8gGIk6ONDweUEzGzhSDIXWiDg8BxUHaRwnphy29dI/Lfiluj5w=
+    on:
+      branch: master
+    app: beis-roda-production

--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem "mini_racer"
 gem "puma", "~> 4.1"
 gem "rollbar"
 gem "rails", "~> 6.0.0"
+gem "sassc", "~> 2.0.1" # Downgrade to fix https://github.com/sass/sassc-ruby/issues/133
 gem "sass-rails", "~> 6.0"
 gem "turbolinks", "~> 5"
 gem "tzinfo-data", platforms: %i[mingw mswin x64_mingw jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -277,8 +277,9 @@ GEM
     safe_yaml (1.0.5)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
-    sassc (2.2.1)
+    sassc (2.0.1)
       ffi (~> 1.9)
+      rake
     sassc-rails (2.1.2)
       railties (>= 4.0.0)
       sassc (>= 2.0)
@@ -368,6 +369,7 @@ DEPENDENCIES
   rollbar
   rspec-rails
   sass-rails (~> 6.0)
+  sassc (~> 2.0.1)
   selenium-webdriver
   spring
   spring-commands-rspec

--- a/heroku.yml
+++ b/heroku.yml
@@ -1,0 +1,10 @@
+build:
+  docker:
+    web: Dockerfile
+release:
+  image: web
+  command:
+    - rake db:migrate
+run:
+  web: bundle exec puma -C config/puma.rb
+


### PR DESCRIPTION
## Changes in this PR

- automatic container deployment on staging when merges to `develop` 
- automatic container deployment to production when merges to `master` - this was done to help facilitate testing as production wasn't being used
- fix Heroku container deployment problem. Containers would be built successfully but then fail during the release phase due to [some low level compiler errors similar to this](https://github.com/sass/sassc-ruby/issues/133). On investigation we tracked down a [commit that added standard.rb](https://github.com/dxw/rails-template/commit/dbc14a6e943f7f9baa3804a0d5946b0ad5c4879c) in our rails-template, this change bumped the version of the sass compiler to `2.2.1`. When reverting this change the release then succeeds so to fix the problem we lock `sassc` to the minor version `2.0.x` until they have a fix in place.

Currently this branch has been force pushed to master and can be reviewed at the [URL](https://beis-roda-production.herokuapp.com/) to verify the assets are *still* compiled correctly and within [Travis's build job](https://travis-ci.org/UKGovernmentBEIS/beis-report-overseas-development-assistance/jobs/608766765?utm_medium=notification&utm_source=github_status) to verify containers were deployed against the expected Git SHA: `677a310be6ca3858fa32462b23fd800026e81683`.

# Next steps

- [ ] readd master branch protections via GitHub
