### PR TITLE
Fix: correct I18n strings

### DIFF
--- a/app/views/staff/organisations/show.html.haml
+++ b/app/views/staff/organisations/show.html.haml
@@ -12,18 +12,18 @@
     .govuk-grid-column-two-thirds
       %dl
         %dt
-          = t("organisation.name")
+          = t("organisation.name.label")
         %dd
           = @organisation_presenter.name
         %dt
-          = t("organisation.type")
+          = t("organisation.type.label")
         %dd
           = t("organisation.organisation_type.#{@organisation_presenter.organisation_type}")
         %dt
-          = t("organisation.language_code")
+          = t("organisation.language_code.label")
         %dd
           = t("organisation.language_code.#{@organisation_presenter.language_code}")
         %dt
-          = t("organisation.default_currency")
+          = t("organisation.default_currency.label")
         %dd
           = t("organisation.default_currency.#{@organisation_presenter.default_currency}")

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -26,10 +26,14 @@ en:
       sign_out: Sign out
       start_now: Start now
   organisation:
-    default_currency: Default currency
-    language_code: Language code
-    name: Name
-    type: Type
+    default_currency:
+      label: Default currency
+    language_code:
+      label: Language code
+    name:
+      label: Name
+    type:
+      label: Type
   organisations:
     create_new: New organisation
     title: Organisations


### PR DESCRIPTION
During the demo on 12/11/2019 I noticed that the i18n strings on the Organisation
show page were not correct. Due to a clash between the `en.yml` and `iati.yml`
the labels for these fields were not being rendered correctly.

`en.yml` had `organisation.language_code` while `iati.yml` had multiple
`organisation.language_code.*` entries; as a result `organisation.language_code`
did not render correctly (the fallback to 'Language Code' was used).

