### PR TITLE
Allow failing specs to be run in isolation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ db/*.sqlite3
 /public/stylesheets/compiled
 /public/system/*
 /spec/tmp/*
+/spec/examples.txt
 /cache
 /capybara*
 /capybara-*.html

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -64,11 +64,12 @@ RSpec.configure do |config|
   #   # aliases for `it`, `describe`, and `context` that include `:focus`
   #   # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
   #   config.filter_run_when_matching :focus
-  #
-  #   # Allows RSpec to persist some state between runs in order to support
-  #   # the `--only-failures` and `--next-failure` CLI options. We recommend
-  #   # you configure your source control system to ignore this file.
-  #   config.example_status_persistence_file_path = "spec/examples.txt"
+
+  # Allows RSpec to persist some state between runs in order to support
+  # the `--only-failures` and `--next-failure` CLI options. We recommend
+  # you configure your source control system to ignore this file.
+  config.example_status_persistence_file_path = "spec/examples.txt"
+
   #
   #   # Limits the available syntax to the non-monkey patched syntax that is
   #   # recommended. For more details, see:


### PR DESCRIPTION
Uncomment the `config.example_status_persistence_file_path` setting in RSpec. 

This allows us to run *only* failing specs using `rspec --only-failures`.
